### PR TITLE
Add CETA-GRID to sites.json

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -67,5 +67,17 @@
             "eosc-synergy.eu": "fdfa9b81582447729f16de6cf61b16e4",
             "covid19.eosc-synergy.eu": "36b6d10a0c194fa8991e7e8d15297478"
         }
+    },
+    {
+        "name": "CETA-GRID",
+        "url": "https://controller.ceta-ciemat.es:5000",
+        "id": "7540G0",
+        "vos": {
+            "eosc-synergy.eu": "0819ebde41fd4c0d95560fc23dc575a4",
+            "covid19.eosc-synergy.eu": "e3716e9fb6a241fd91469a6ee05358a1",
+            "o3as.data.kit.edu": "91b83525d63c48d78740e6799cfed2c4",
+            "worsica.vo.indc.pt": "38414631e27c485eae87f6dcb3082873",
+            "fedcloud.egi.eu": "aa7f62b244c946038c093d0bf05827a1"
+        }
     }
 ]


### PR DESCRIPTION
Hi Miguel, 

As agreed in one of the latest EOSC-Synergy WP2 meetings, we would like to add CETA-GRID site and its supported VOs to the site.

Thanks in advance,

J.M.